### PR TITLE
bump go version to avoid build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jonnylangefeld/datadog-operator
 
-go 1.16
+go 1.17
 
 require (
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
Currently I am seeing build failed with incorrectly set version 
https://github.com/kubernetes-sigs/controller-tools/issues/643