### PR TITLE
comitting pflag to parse arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"os"
 
 	"github.com/spf13/viper"
@@ -41,7 +40,7 @@ func main() {
 	pflag.StringVarP(&metricsAddr, "metrics-addr", "m", ":8080", "The address the metric endpoint binds to.")
 	pflag.BoolVarP(&enableLeaderElection, "enable-leader-election", "l", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	pflag.StringVarP(&secretsPath, "secrets-path", "s", ".secrets.json", "The path to the config file")
-	flag.Parse()
+	pflag.Parse()
 	viper.SetConfigFile(secretsPath)
 	viper.AddConfigPath(".")
 	_ = viper.ReadInConfig()


### PR DESCRIPTION
Previously we were not taking these arguments 
- validated that now we can see 

`go run main.go -s          
flag needs an argument: 's' in -s
Usage of /var/folders/dx/y8d0_831301fmr1ghddksbv00000gp/T/go-build2686520181/b001/exe/main:
  -l, --enable-leader-election   Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
  -m, --metrics-addr string      The address the metric endpoint binds to. (default ":8080")
  -s, --secrets-path string      The path to the config file (default ".secrets.json")
flag needs an argument: 's' in -s`