### PR TITLE
Bump rbac version to match kubebuidler v3 

### DIFF
--- a/config/daytona/envvar.env
+++ b/config/daytona/envvar.env
@@ -1,8 +1,0 @@
-DAYTONA_SECRET_DESTINATION_PATH=defaultPath 
-K8S_AUTH="true"
-K8S_AUTH_MOUNT=AuthPath 
-SECRET_ENV="true"
-TOKEN_PATH=TokenPath
-VAULT_ADDR=VaultAddr 
-VAULT_AUTH_ROLE=datadog-operator
-VAULT_SECRETS_PATH=SecretPath 

--- a/config/daytona/envvar.env
+++ b/config/daytona/envvar.env
@@ -1,0 +1,8 @@
+DAYTONA_SECRET_DESTINATION_PATH=defaultPath 
+K8S_AUTH="true"
+K8S_AUTH_MOUNT=AuthPath 
+SECRET_ENV="true"
+TOKEN_PATH=TokenPath
+VAULT_ADDR=VaultAddr 
+VAULT_AUTH_ROLE=datadog-operator
+VAULT_SECRETS_PATH=SecretPath 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,3 +25,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update

--- a/controllers/datadog/monitor_controller.go
+++ b/controllers/datadog/monitor_controller.go
@@ -44,6 +44,7 @@ type MonitorReconciler struct {
 
 // +kubebuilder:rbac:groups=datadog.jonnylangefeld.com,resources=monitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=datadog.jonnylangefeld.com,resources=monitors/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 
 func (r *MonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("monitor", req.NamespacedName)

--- a/main.go
+++ b/main.go
@@ -46,7 +46,8 @@ func main() {
 	viper.AddConfigPath(".")
 	err := viper.ReadInConfig()
 	if err != nil {
-		fmt.Println(err)
+		setupLog.Error(err, "unable to fetch datadog secret")
+		os.Exit(1)
 	}
 	viper.SetEnvPrefix("datadog")
 	viper.AutomaticEnv()


### PR DESCRIPTION
This enables running containers to be run as nonroot which is safer practice, and it will match kubebuilder v3 standard version. 

`The version of the image gcr.io/kubebuilder/kube-rbac-proxy, which is an optional component enabled by default to secure the request made against the manager, was updated from 0.5.0 to 0.8.0 to address security concerns. The details of all changes can be found in [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy/releases).`

